### PR TITLE
enforce lf ending for bin script

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+[goofoffline]
+#a bin script, i.e. a node script with shebang MUST be lf, otherwise it won't work on POSIX
+#-> https://github.com/npm/npm/issues/4607
+end_of_line = lf
+charset = utf-8

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+#force lf for bin script
+goofoffline eol=lf

--- a/bin/goofoffline
+++ b/bin/goofoffline
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-"use strict";
+'use strict';
 var path = require('path'),
     fs = require('fs'),
     url = require('url'),


### PR DESCRIPTION
The published package on NPM does have CRLF line endings (aka Windows line endings) in the bin script - this does not work on POSIX platforms. However the other way around, it should be no problem.

See https://github.com/npm/npm/issues/4607

I have added editorconfig + .gitattributes, to enforce LF line endings just for the bin script across platforms and made small change to goofoffline, to force an update.

I have tested it on Windows and the line endings are correct now. If you publish a new version on NPM all POSIX users would be grateful I guess. :)